### PR TITLE
delete Keyboard#destroy() and MultiKeyboard#destroy()

### DIFF
--- a/src/Keyboard.ts
+++ b/src/Keyboard.ts
@@ -243,22 +243,6 @@ export class Keyboard extends g.E {
 		this.keyboardBack.modified();
 	}
 
-	destroy(): void {
-		super.destroy();
-		this.common.destroy();
-		this.common = null;
-		this.kanaKey.destroy();
-		this.kanaKey = null;
-		this.keyboardBack.destroy();
-		this.keyboardBack = null;
-		this.inputtingLabelBack.destroy();
-		this.inputtingLabelBack = null;
-		this.inputtingLabel.destroy();
-		this.inputtingLabel = null;
-		this.backSpaceKey.destroy();
-		this.backSpaceKey = null;
-	}
-
 	get text(): string {
 		return this.inputtingLabel.text;
 	}

--- a/src/MultiKeyboard.ts
+++ b/src/MultiKeyboard.ts
@@ -170,18 +170,4 @@ export class MultiKeyboard extends Keyboard {
 		});
 		this.common.append(this.convSym);
 	}
-
-	destroy(): void {
-		super.destroy();
-		this.alphaKey.destroy();
-		this.alphaKey = null;
-		this.symKey.destroy();
-		this.symKey = null;
-		this.convKana.destroy();
-		this.convKana = null;
-		this.convAlpha.destroy();
-		this.convAlpha = null;
-		this.convSym.destroy();
-		this.convSym = null;
-	}
 }


### PR DESCRIPTION
### 概要
* このコンテンツで`Scene#replaceScene()`を実行した場合、エラーでコンテンツが動かなくなってしまう問題が発覚しました。
  * その原因が、`Keyboard#destroy()` や `MultiKeyboard#destroy()`で親エンティティdestroy後に子エンティティをdestroyしようとしまっていることでした
  * ただ、親エンティティをdestroyすれば子エンティティもdestroyされるはずなので、そもそも`Keyboard#destroy()` や `MultiKeyboard#destroy()`で子エンティティを削除する処理は不要かと思われます。
  * なので、このPRでは`Keyboard#destroy()` と `MultiKeyboard#destroy()`を削除する対応を行います

### 確認方法
src/main.tsの`scene.onLoad`に登録するハンドラの処理に以下コードを追記し、シーン遷移時に問題ないことを確認
```
+               // scene遷移するエンティティ
+               const testEntity = new g.FilledRect({
+                       scene,
+                       cssColor: "red",
+                       width: 50,
+                       height: 50,
+                       touchable: true
+               });
+               testEntity.onPointUp.add(() => {
+                       const newScene = new g.Scene({ game });
+                       newScene.onLoad.add(() => {
+                               const rect = new g.FilledRect({
+                                       scene: newScene,
+                                       cssColor: "blue",
+                                       width: 200,
+                                       height: 200
+                               });
+                               newScene.append(rect);
+                       });
+                       game.replaceScene(newScene);
+               });
+               scene.append(testEntity);

```